### PR TITLE
feat: Supports reserved word highlighting

### DIFF
--- a/vdmpp/package.json
+++ b/vdmpp/package.json
@@ -331,6 +331,14 @@
       {
         "scopeName": "source.vdmpp.number",
         "path": "./syntaxes/number.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.type",
+        "path": "./syntaxes/type.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.statements",
+        "path": "./syntaxes/statements.tmLanguage.json"
       }
     ],
     "debuggers": [

--- a/vdmpp/syntaxes/statements.tmLanguage.json
+++ b/vdmpp/syntaxes/statements.tmLanguage.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "statements",
+	"patterns": [
+		{
+			"include": "#statements"
+		}
+	],
+	"repository": {
+		"statements": {
+			"name": "meta.statements.vdmpp",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#control-statements"
+				},
+				{
+					"include": "#local-binding-statements"
+				},
+				{
+					"include": "#expressions"
+				},
+				{
+					"include": "#others"
+				},
+				{
+					"include": "#operator"
+				}
+			]
+		},
+		"comment": {
+			"patterns": [
+				{
+					"name": "comment.line.double-dash.vdmpp",
+					"match": "--.*"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.vdmpp",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.vdmpp",
+					"match": "\\\\."
+				}
+			]
+		},
+		"control-statements": {
+			"patterns": [
+				{
+					"name": "keyword.control.statements.conditional.vdmpp",
+					"match": "\\b(if|then|else|elseif|cases|end)\\b"
+				}
+			]
+		},
+		"local-binding-statements":{
+			"patterns": [
+				{
+					"name": "storage.type.vdmpp",
+					"match": "\\b(let)\\b"
+				}
+			]
+		},
+		"expressions": {
+			"patterns": [
+				{
+					"name": "keyword.operator.expressions.binary.vdmpp",
+					"match": "\\b(div|rem|mod|or|and|in set|not in set|subset|psubset|union|inter|munion|comp)\\b"
+				},
+				{
+					"name": "keyword.operator.expressions.unary.vdmpp",
+					"match": "\\b(abs|floor|not|card|power|dunion|dinter|hd|tl|len|elems|inds|reverse|conc|dom|rng|merge|inverse|mod|in|set|comp|and|or)\\b"
+				}
+			]
+		},
+		"others": {
+			"patterns": [
+				{
+					"name": "keyword.other.vdmpp",
+					"match": "\\b(#act|#active|#else|#endif|#fin|#ifdef|#ifndef|#req|#waiting|abs|all|always|and|async|atomic|be|bool|by|card|cases|char|class|comp|compose|conc|dcl|def|dinter|div|do|dom|dunion|elems|else|elseif|end|error|errs|eq|exists|exists1|exit|ext|false|floor|for|forall|from|functions|hd|if|in|inds|inmap|instance|int|inter|inv|inverse|iota|is|isofbaseclass|isofclass|lambda|len|let|map|measure|merge|mod|mu|munion|mutex|nat|nat1|new|nil|not|of|operations|or|ord|others|per|periodic|post|power|pre|private|protected|psubset|public|pure|rat|rd|real|rem|responsibility|return|reverse|rng|samebaseclass|sameclass|self|seq|seq1|set|set1|skip|specified|sporadic|st|static|start|startlist|stop|stoplist|subclass|subset|sync|then|thread|threadid|tixe|tl|to|token|traces|trap|true|types|undefined|union|values|variables|while|with|wr|yet|RESULT)\\b"
+				}
+			]
+		},
+		"operator": {
+			"patterns": [
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
+				},
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
+				},
+				{
+					"name": "keyword.operator.new.vdmpp",
+					"match": "\\b(new)\\b"
+				}
+			]
+		}
+	},
+	"scopeName": "source.vdmpp.statements"
+}

--- a/vdmpp/syntaxes/type.tmLanguage.json
+++ b/vdmpp/syntaxes/type.tmLanguage.json
@@ -1,0 +1,65 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "type",
+	"patterns": [
+		{
+			"include": "#type"
+		}
+	],
+	"repository": {
+		"type": {
+			"patterns": [
+				{
+					"include": "#seq-of"
+				},
+				{
+					"include": "#map-to"
+                },
+                {
+                    "include": "#enum"
+                },
+				{
+					"name": "support.type.basic.vdmpp",
+					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
+				}
+			]
+		},
+		"seq-of": {
+			"match": "(seq of) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+		},
+		"map-to": {
+			"match": "(map) (\\S+) (to) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				},
+				"3": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"4": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+        },
+        "enum":{
+            "match": "<([^>]+)>",
+            "captures": {
+                "1": {
+                    "name": "support.type.basic.vdmpp"
+                }
+            }
+        }
+	},
+	"scopeName": "source.vdmpp.type"
+}

--- a/vdmpp/syntaxes/vdmpp.tmLanguage.json
+++ b/vdmpp/syntaxes/vdmpp.tmLanguage.json
@@ -6,135 +6,10 @@
 			"include": "#class-declator"
 		},
 		{
-			"include": "#statement"
+			"include": "#statements"
 		}
 	],
 	"repository": {
-		"statement": {
-			"patterns": [
-				{
-					"include": "#comment"
-				},
-				{
-					"include": "#modifier"
-				},
-				{
-					"include": "#definitions"
-				},
-				{
-					"include": "#strings"
-				},
-				{
-					"include": "#types"
-				},
-				{
-					"include": "#keywords"
-				},
-				{
-					"include": "source.vdmpp.number"
-				},
-				{
-					"include": "#method-name"
-				},
-				{
-					"include": "#operator"
-				}
-			]
-		},
-		"comment": {
-			"patterns": [
-				{
-					"name": "comment.line.double-dash.vdmpp",
-					"match": "--.*"
-				}
-			]
-		},
-		"definitions": {
-			"patterns": [
-				{
-					"name": "entity.name.section.vdmpp",
-					"match": "\\b(operations|functions|types|values|instance variables)\\b"
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.control.vdmpp",
-					"match": "\\b(if|else|then|return|forall)\\b"
-				}
-			]
-		},
-		"method-name": {
-			"name": "meta.use-method.vdmpp",
-			"begin": "(\\S+)\\(",
-			"end": "\\)",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.vdmpp"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#variable-name"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.vdmpp",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.vdmpp",
-					"match": "\\\\."
-				}
-			]
-		},
-		"modifier": {
-			"patterns": [
-				{
-					"name": "storage.modifier.vdmpp",
-					"match": "\\b(public|private|static|pre|post|pure)\\b"
-				},
-				{
-					"name": "storage.type.vdmpp",
-					"match": "\\b(let)\\b"
-				}
-			]
-		},
-		"types": {
-			"patterns": [
-				{
-					"name": "support.type.basic.vdmpp",
-					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
-				}
-			]
-		},
-		"operator": {
-			"patterns": [
-				{
-					"name": "keyword.operator.assignment.vdmpp",
-					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
-				},
-				{
-					"name": "keyword.operator.assignment.vdmpp",
-					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
-				},
-				{
-					"name": "keyword.operator.new.vdmpp",
-					"match": "\\b(new)\\b"
-				}
-			]
-		},
-		"variable-name": {
-			"patterns": [
-				{
-					"name": "variable.other.readwrite.vdmpp",
-					"match": "([^:()\\s=>])"
-				}
-			]
-		},
 		"class-declator": {
 			"name": "meta.class.vdmpp",
 			"begin": "(class)\\s+(\\S+)",
@@ -157,18 +32,197 @@
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
+					"include": "#functions-definition"
 				},
 				{
-					"include": "#value-declator"
+					"include": "#operations-definition"
 				},
 				{
-					"include": "#statement"
+					"include": "#values-definition"
+				},
+				{
+					"include": "#types-definition"
+				},
+				{
+					"include": "#instance-variables-definition"
+				},
+				{
+					"include": "#statements"
 				}
 			]
 		},
-		"value-declator": {
-			"name": "meta.value.vdmpp",
+		"statements": {
+			"patterns": [
+				{
+					"include": "#modifier"
+				},
+				{
+					"include": "#definitions"
+				},
+				{
+					"include": "source.vdmpp.type"
+				},
+				{
+					"include": "source.vdmpp.number"
+				},
+				{
+					"include": "source.vdmpp.statements"
+				}
+			]
+		},
+		"definitions": {
+			"patterns": [
+				{
+					"name": "entity.name.function.vdmpp",
+					"match": "\\b(operations|functions|types|values|instance variables)\\b"
+				}
+			]
+		},
+		"modifier": {
+			"patterns": [
+				{
+					"name": "storage.modifier.vdmpp",
+					"match": "\\b(public|private|static|pre|post|pure)\\b"
+				}
+			]
+		},
+		"variable-name": {
+			"patterns": [
+				{
+					"name": "variable.other.readwrite.vdmpp",
+					"match": "([^:()\\s=>])"
+				}
+			]
+		},
+		"instance-variables-definition": {
+			"name": "meta.instance-variables.vdmpp",
+			"begin": "\\b(instance variables)\\b",
+			"end": "(.*)(?=(operations|functions|types|values|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#instance-variables-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"instance-variables-declator": {
+			"name": "meta.instance-variables.declator.vdmpp",
+			"begin": "(\\S+)\\s*:\\s*([^;\\n]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"include": "#statements"
+						}
+					]
+				}
+			}
+		},
+		"types-definition": {
+			"name": "meta.types.vdmpp",
+			"begin": "\\b(types)\\b",
+			"end": "(.*)(?=(operations|functions|values|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#types-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"types-declator": {
+			"name": "meta.types.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s+=\\s+([^;]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-definition": {
+			"name": "meta.values.vdmpp",
+			"begin": "\\b(values)\\b",
+			"end": "(.*)(?=(operations|functions|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#values-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-declator": {
+			"name": "meta.values.declator.vdmpp",
 			"begin": "(public|private)\\s+(static)\\s+(\\S+)\\s+:\\s+(\\S+)",
 			"end": ";",
 			"beginCaptures": {
@@ -196,7 +250,7 @@
 				"4": {
 					"patterns": [
 						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
 							"name": "support.type.primitive.vdmpp",
@@ -215,16 +269,38 @@
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
-				},
-				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
 		},
-		"function-declator": {
-			"name": "meta.function.vdmpp",
-			"begin": "(public|private)\\s+(\\S+)\\s+:\\s+(\\S+)\\s+(==>|->)\\s+(seq of char|\\S+)",
+		"functions-definition": {
+			"name": "meta.functions.vdmpp",
+			"begin": "\\b(functions)\\b",
+			"end": ".*(?=operations|values|types|instance variables|end)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#functions-declator"
+				},
+				{
+					"include": "#functions-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"functions-declator": {
+			"name": "meta.functions.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
 					"patterns": [
@@ -239,21 +315,7 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "#types"
-						},
-						{
-							"name": "support.type.primitive.vdmpp",
-							"match": "\\S+"
-						}
-					]
-				},
-				"4": {
-					"name": "storage.type.function.arrow.js"
-				},
-				"5": {
-					"patterns": [
-						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
 							"name": "support.type.primitive.vdmpp",
@@ -262,12 +324,145 @@
 					]
 				}
 			},
-			"end": ";",
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.arrow.js"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
 			"patterns": [
 				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
+		},
+		"functions-implementation": {
+			"name": "meta.functions.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-definition": {
+			"name": "meta.operations.vdmpp",
+			"begin": "\\b(operations)\\b",
+			"end": "(.*)(?=(functions|values|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#operations-declator"
+				},
+				{
+					"include": "#operations-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-declator": {
+			"name": "meta.operations.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"name": "entity.name.function"
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.arrow.js"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-implementation": {
+			"name": "meta.operations.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#use-function"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"use-function":{
+			"name": "meta.use-function.vdmpp",
+			"begin": "(\\S+)\\s*\\(",
+			"end": "\\)",
+			"beginCaptures": {
+				"1":{
+					"name": "support.function.vdmpp"
+				}
+			}
 		}
 	},
 	"scopeName": "source.vdmpp"

--- a/vdmrt/package.json
+++ b/vdmrt/package.json
@@ -331,6 +331,14 @@
       {
         "scopeName": "source.vdmrt.number",
         "path": "./syntaxes/number.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.type",
+        "path": "./syntaxes/type.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.statements",
+        "path": "./syntaxes/statements.tmLanguage.json"
       }
     ],
     "debuggers": [

--- a/vdmrt/package.json
+++ b/vdmrt/package.json
@@ -333,11 +333,11 @@
         "path": "./syntaxes/number.tmLanguage.json"
       },
       {
-        "scopeName": "source.vdmpp.type",
+        "scopeName": "source.vdmrt.type",
         "path": "./syntaxes/type.tmLanguage.json"
       },
       {
-        "scopeName": "source.vdmpp.statements",
+        "scopeName": "source.vdmrt.statements",
         "path": "./syntaxes/statements.tmLanguage.json"
       }
     ],

--- a/vdmrt/syntaxes/statements.tmLanguage.json
+++ b/vdmrt/syntaxes/statements.tmLanguage.json
@@ -8,7 +8,7 @@
 	],
 	"repository": {
 		"statements": {
-			"name": "meta.statements.vdmpp",
+			"name": "meta.statements.vdmrt",
 			"patterns": [
 				{
 					"include": "#comment"
@@ -36,18 +36,18 @@
 		"comment": {
 			"patterns": [
 				{
-					"name": "comment.line.double-dash.vdmpp",
+					"name": "comment.line.double-dash.vdmrt",
 					"match": "--.*"
 				}
 			]
 		},
 		"strings": {
-			"name": "string.quoted.double.vdmpp",
+			"name": "string.quoted.double.vdmrt",
 			"begin": "\"",
 			"end": "\"",
 			"patterns": [
 				{
-					"name": "constant.character.escape.vdmpp",
+					"name": "constant.character.escape.vdmrt",
 					"match": "\\\\."
 				}
 			]
@@ -55,7 +55,7 @@
 		"control-statements": {
 			"patterns": [
 				{
-					"name": "keyword.control.statements.conditional.vdmpp",
+					"name": "keyword.control.statements.conditional.vdmrt",
 					"match": "\\b(if|then|else|elseif|cases|end)\\b"
 				}
 			]
@@ -63,7 +63,7 @@
 		"local-binding-statements":{
 			"patterns": [
 				{
-					"name": "storage.type.vdmpp",
+					"name": "storage.type.vdmrt",
 					"match": "\\b(let)\\b"
 				}
 			]
@@ -71,11 +71,11 @@
 		"expressions": {
 			"patterns": [
 				{
-					"name": "keyword.operator.expressions.binary.vdmpp",
+					"name": "keyword.operator.expressions.binary.vdmrt",
 					"match": "\\b(div|rem|mod|or|and|in set|not in set|subset|psubset|union|inter|munion|comp)\\b"
 				},
 				{
-					"name": "keyword.operator.expressions.unary.vdmpp",
+					"name": "keyword.operator.expressions.unary.vdmrt",
 					"match": "\\b(abs|floor|not|card|power|dunion|dinter|hd|tl|len|elems|inds|reverse|conc|dom|rng|merge|inverse|mod|in|set|comp|and|or)\\b"
 				}
 			]
@@ -91,19 +91,19 @@
 		"operator": {
 			"patterns": [
 				{
-					"name": "keyword.operator.assignment.vdmpp",
+					"name": "keyword.operator.assignment.vdmrt",
 					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
 				},
 				{
-					"name": "keyword.operator.assignment.vdmpp",
+					"name": "keyword.operator.assignment.vdmrt",
 					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
 				},
 				{
-					"name": "keyword.operator.new.vdmpp",
+					"name": "keyword.operator.new.vdmrt",
 					"match": "\\b(new)\\b"
 				}
 			]
 		}
 	},
-	"scopeName": "source.vdmpp.statements"
+	"scopeName": "source.vdmrt.statements"
 }

--- a/vdmrt/syntaxes/statements.tmLanguage.json
+++ b/vdmrt/syntaxes/statements.tmLanguage.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "statements",
+	"patterns": [
+		{
+			"include": "#statements"
+		}
+	],
+	"repository": {
+		"statements": {
+			"name": "meta.statements.vdmpp",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#control-statements"
+				},
+				{
+					"include": "#local-binding-statements"
+				},
+				{
+					"include": "#expressions"
+				},
+				{
+					"include": "#others"
+				},
+				{
+					"include": "#operator"
+				}
+			]
+		},
+		"comment": {
+			"patterns": [
+				{
+					"name": "comment.line.double-dash.vdmpp",
+					"match": "--.*"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.vdmpp",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.vdmpp",
+					"match": "\\\\."
+				}
+			]
+		},
+		"control-statements": {
+			"patterns": [
+				{
+					"name": "keyword.control.statements.conditional.vdmpp",
+					"match": "\\b(if|then|else|elseif|cases|end)\\b"
+				}
+			]
+		},
+		"local-binding-statements":{
+			"patterns": [
+				{
+					"name": "storage.type.vdmpp",
+					"match": "\\b(let)\\b"
+				}
+			]
+		},
+		"expressions": {
+			"patterns": [
+				{
+					"name": "keyword.operator.expressions.binary.vdmpp",
+					"match": "\\b(div|rem|mod|or|and|in set|not in set|subset|psubset|union|inter|munion|comp)\\b"
+				},
+				{
+					"name": "keyword.operator.expressions.unary.vdmpp",
+					"match": "\\b(abs|floor|not|card|power|dunion|dinter|hd|tl|len|elems|inds|reverse|conc|dom|rng|merge|inverse|mod|in|set|comp|and|or)\\b"
+				}
+			]
+		},
+		"others": {
+			"patterns": [
+				{
+					"name": "keyword.other.vdmrt",
+					"match": "\\b(#act|#active|#else|#endif|#fin|#ifdef|#ifndef|#req|#waiting|abs|all|always|and|async|atomic|be|bool|by|card|cases|char|class|comp|compose|conc|cycles|dcl|def|dinter|div|do|dom|dunion|duration|elems|else|elseif|end|error|errs|eq|exists|exists1|exit|ext|false|floor|for|forall|from|functions|hd|if|in|inds|inmap|instance|int|inter|inv|inverse|iota|is|isofbaseclass|isofclass|lambda|len|let|map|measure|merge|mod|mu|munion|mutex|nat|nat1|new|nil|not|of|operations|or|ord|others|per|periodic|post|power|pre|private|protected|psubset|public|pure|rat|rd|real|rem|responsibility|return|reverse|rng|samebaseclass|sameclass|self|seq|seq1|set|set1|skip|specified|sporadic|st|static|start|startlist|stop|stoplist|subclass|subset|sync|system|then|thread|threadid|time|tixe|tl|to|token|traces|trap|true|types|undefined|union|values|variables|while|with|wr|yet|RESULT)\\b"
+				}
+			]
+		},
+		"operator": {
+			"patterns": [
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
+				},
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
+				},
+				{
+					"name": "keyword.operator.new.vdmpp",
+					"match": "\\b(new)\\b"
+				}
+			]
+		}
+	},
+	"scopeName": "source.vdmpp.statements"
+}

--- a/vdmrt/syntaxes/type.tmLanguage.json
+++ b/vdmrt/syntaxes/type.tmLanguage.json
@@ -1,0 +1,65 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "type",
+	"patterns": [
+		{
+			"include": "#type"
+		}
+	],
+	"repository": {
+		"type": {
+			"patterns": [
+				{
+					"include": "#seq-of"
+				},
+				{
+					"include": "#map-to"
+                },
+                {
+                    "include": "#enum"
+                },
+				{
+					"name": "support.type.basic.vdmpp",
+					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
+				}
+			]
+		},
+		"seq-of": {
+			"match": "(seq of) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+		},
+		"map-to": {
+			"match": "(map) (\\S+) (to) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				},
+				"3": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"4": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+        },
+        "enum":{
+            "match": "<([^>]+)>",
+            "captures": {
+                "1": {
+                    "name": "support.type.basic.vdmpp"
+                }
+            }
+        }
+	},
+	"scopeName": "source.vdmpp.type"
+}

--- a/vdmrt/syntaxes/type.tmLanguage.json
+++ b/vdmrt/syntaxes/type.tmLanguage.json
@@ -19,7 +19,7 @@
                     "include": "#enum"
                 },
 				{
-					"name": "support.type.basic.vdmpp",
+					"name": "support.type.basic.vdmrt",
 					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
 				}
 			]
@@ -28,10 +28,10 @@
 			"match": "(seq of) (\\S+)",
 			"captures": {
 				"1": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmrt"
 				},
 				"2": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				}
 			}
 		},
@@ -39,16 +39,16 @@
 			"match": "(map) (\\S+) (to) (\\S+)",
 			"captures": {
 				"1": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmrt"
 				},
 				"2": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				},
 				"3": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmrt"
 				},
 				"4": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				}
 			}
         },
@@ -56,10 +56,10 @@
             "match": "<([^>]+)>",
             "captures": {
                 "1": {
-                    "name": "support.type.basic.vdmpp"
+                    "name": "support.type.basic.vdmrt"
                 }
             }
         }
 	},
-	"scopeName": "source.vdmpp.type"
+	"scopeName": "source.vdmrt.type"
 }

--- a/vdmrt/syntaxes/vdmrt.tmLanguage.json
+++ b/vdmrt/syntaxes/vdmrt.tmLanguage.json
@@ -6,135 +6,10 @@
 			"include": "#class-declator"
 		},
 		{
-			"include": "#statement"
+			"include": "#statements"
 		}
 	],
 	"repository": {
-		"statement": {
-			"patterns": [
-				{
-					"include": "#comment"
-				},
-				{
-					"include": "#modifier"
-				},
-				{
-					"include": "#definitions"
-				},
-				{
-					"include": "#strings"
-				},
-				{
-					"include": "#types"
-				},
-				{
-					"include": "#keywords"
-				},
-				{
-					"include": "source.vdmpp.number"
-				},
-				{
-					"include": "#method-name"
-				},
-				{
-					"include": "#operator"
-				}
-			]
-		},
-		"comment": {
-			"patterns": [
-				{
-					"name": "comment.line.double-dash.vdmpp",
-					"match": "--.*"
-				}
-			]
-		},
-		"definitions": {
-			"patterns": [
-				{
-					"name": "entity.name.section.vdmpp",
-					"match": "\\b(operations|functions|types|values|instance variables)\\b"
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.control.vdmpp",
-					"match": "\\b(if|else|then|return|forall)\\b"
-				}
-			]
-		},
-		"method-name": {
-			"name": "meta.use-method.vdmpp",
-			"begin": "(\\S+)\\(",
-			"end": "\\)",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.vdmpp"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#variable-name"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.vdmpp",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.vdmpp",
-					"match": "\\\\."
-				}
-			]
-		},
-		"modifier": {
-			"patterns": [
-				{
-					"name": "storage.modifier.vdmpp",
-					"match": "\\b(public|private|static|pre|post|pure)\\b"
-				},
-				{
-					"name": "storage.type.vdmpp",
-					"match": "\\b(let)\\b"
-				}
-			]
-		},
-		"types": {
-			"patterns": [
-				{
-					"name": "support.type.basic.vdmpp",
-					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
-				}
-			]
-		},
-		"operator": {
-			"patterns": [
-				{
-					"name": "keyword.operator.assignment.vdmpp",
-					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
-				},
-				{
-					"name": "keyword.operator.assignment.vdmpp",
-					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
-				},
-				{
-					"name": "keyword.operator.new.vdmpp",
-					"match": "\\b(new)\\b"
-				}
-			]
-		},
-		"variable-name": {
-			"patterns": [
-				{
-					"name": "variable.other.readwrite.vdmpp",
-					"match": "([^:()\\s=>])"
-				}
-			]
-		},
 		"class-declator": {
 			"name": "meta.class.vdmpp",
 			"begin": "(class)\\s+(\\S+)",
@@ -157,18 +32,197 @@
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
+					"include": "#functions-definition"
 				},
 				{
-					"include": "#value-declator"
+					"include": "#operations-definition"
 				},
 				{
-					"include": "#statement"
+					"include": "#values-definition"
+				},
+				{
+					"include": "#types-definition"
+				},
+				{
+					"include": "#instance-variables-definition"
+				},
+				{
+					"include": "#statements"
 				}
 			]
 		},
-		"value-declator": {
-			"name": "meta.value.vdmpp",
+		"statements": {
+			"patterns": [
+				{
+					"include": "#modifier"
+				},
+				{
+					"include": "#definitions"
+				},
+				{
+					"include": "source.vdmpp.type"
+				},
+				{
+					"include": "source.vdmpp.number"
+				},
+				{
+					"include": "source.vdmpp.statements"
+				}
+			]
+		},
+		"definitions": {
+			"patterns": [
+				{
+					"name": "entity.name.function.vdmpp",
+					"match": "\\b(operations|functions|types|values|instance variables)\\b"
+				}
+			]
+		},
+		"modifier": {
+			"patterns": [
+				{
+					"name": "storage.modifier.vdmpp",
+					"match": "\\b(public|private|static|pre|post|pure)\\b"
+				}
+			]
+		},
+		"variable-name": {
+			"patterns": [
+				{
+					"name": "variable.other.readwrite.vdmpp",
+					"match": "([^:()\\s=>])"
+				}
+			]
+		},
+		"instance-variables-definition": {
+			"name": "meta.instance-variables.vdmpp",
+			"begin": "\\b(instance variables)\\b",
+			"end": "(.*)(?=(operations|functions|types|values|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#instance-variables-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"instance-variables-declator": {
+			"name": "meta.instance-variables.declator.vdmpp",
+			"begin": "(\\S+)\\s*:\\s*([^;\\n]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"include": "#statements"
+						}
+					]
+				}
+			}
+		},
+		"types-definition": {
+			"name": "meta.types.vdmpp",
+			"begin": "\\b(types)\\b",
+			"end": "(.*)(?=(operations|functions|values|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#types-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"types-declator": {
+			"name": "meta.types.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s+=\\s+([^;]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-definition": {
+			"name": "meta.values.vdmpp",
+			"begin": "\\b(values)\\b",
+			"end": "(.*)(?=(operations|functions|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#values-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-declator": {
+			"name": "meta.values.declator.vdmpp",
 			"begin": "(public|private)\\s+(static)\\s+(\\S+)\\s+:\\s+(\\S+)",
 			"end": ";",
 			"beginCaptures": {
@@ -196,7 +250,7 @@
 				"4": {
 					"patterns": [
 						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
 							"name": "support.type.primitive.vdmpp",
@@ -215,16 +269,38 @@
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
-				},
-				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
 		},
-		"function-declator": {
-			"name": "meta.function.vdmpp",
-			"begin": "(public|private)\\s+(\\S+)\\s+:\\s+(\\S+)\\s+(==>|->)\\s+(seq of char|\\S+)",
+		"functions-definition": {
+			"name": "meta.functions.vdmpp",
+			"begin": "\\b(functions)\\b",
+			"end": ".*(?=operations|values|types|instance variables|end)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#functions-declator"
+				},
+				{
+					"include": "#functions-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"functions-declator": {
+			"name": "meta.functions.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
 					"patterns": [
@@ -239,21 +315,7 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "#types"
-						},
-						{
-							"name": "support.type.primitive.vdmpp",
-							"match": "\\S+"
-						}
-					]
-				},
-				"4": {
-					"name": "storage.type.function.arrow.js"
-				},
-				"5": {
-					"patterns": [
-						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
 							"name": "support.type.primitive.vdmpp",
@@ -262,12 +324,145 @@
 					]
 				}
 			},
-			"end": ";",
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.arrow.js"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
 			"patterns": [
 				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
+		},
+		"functions-implementation": {
+			"name": "meta.functions.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-definition": {
+			"name": "meta.operations.vdmpp",
+			"begin": "\\b(operations)\\b",
+			"end": "(.*)(?=(functions|values|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#operations-declator"
+				},
+				{
+					"include": "#operations-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-declator": {
+			"name": "meta.operations.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"name": "entity.name.function"
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.arrow.js"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-implementation": {
+			"name": "meta.operations.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#use-function"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"use-function":{
+			"name": "meta.use-function.vdmpp",
+			"begin": "(\\S+)\\s*\\(",
+			"end": "\\)",
+			"beginCaptures": {
+				"1":{
+					"name": "support.function.vdmpp"
+				}
+			}
 		}
 	},
 	"scopeName": "source.vdmrt"

--- a/vdmrt/syntaxes/vdmrt.tmLanguage.json
+++ b/vdmrt/syntaxes/vdmrt.tmLanguage.json
@@ -11,23 +11,23 @@
 	],
 	"repository": {
 		"class-declator": {
-			"name": "meta.class.vdmpp",
+			"name": "meta.class.vdmrt",
 			"begin": "(class)\\s+(\\S+)",
 			"end": "(end)\\s+(\\S+)",
 			"beginCaptures": {
 				"1": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				},
 				"2": {
-					"name": "entity.name.class.vdmpp"
+					"name": "entity.name.class.vdmrt"
 				}
 			},
 			"endCaptures": {
 				"1": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				},
 				"2": {
-					"name": "entity.name.class.vdmpp"
+					"name": "entity.name.class.vdmrt"
 				}
 			},
 			"patterns": [
@@ -60,20 +60,20 @@
 					"include": "#definitions"
 				},
 				{
-					"include": "source.vdmpp.type"
+					"include": "source.vdmrt.type"
 				},
 				{
-					"include": "source.vdmpp.number"
+					"include": "source.vdmrt.number"
 				},
 				{
-					"include": "source.vdmpp.statements"
+					"include": "source.vdmrt.statements"
 				}
 			]
 		},
 		"definitions": {
 			"patterns": [
 				{
-					"name": "entity.name.function.vdmpp",
+					"name": "entity.name.function.vdmrt",
 					"match": "\\b(operations|functions|types|values|instance variables)\\b"
 				}
 			]
@@ -81,7 +81,7 @@
 		"modifier": {
 			"patterns": [
 				{
-					"name": "storage.modifier.vdmpp",
+					"name": "storage.modifier.vdmrt",
 					"match": "\\b(public|private|static|pre|post|pure)\\b"
 				}
 			]
@@ -89,13 +89,13 @@
 		"variable-name": {
 			"patterns": [
 				{
-					"name": "variable.other.readwrite.vdmpp",
+					"name": "variable.other.readwrite.vdmrt",
 					"match": "([^:()\\s=>])"
 				}
 			]
 		},
 		"instance-variables-definition": {
-			"name": "meta.instance-variables.vdmpp",
+			"name": "meta.instance-variables.vdmrt",
 			"begin": "\\b(instance variables)\\b",
 			"end": "(.*)(?=(operations|functions|types|values|end))",
 			"beginCaptures": {
@@ -117,7 +117,7 @@
 			]
 		},
 		"instance-variables-declator": {
-			"name": "meta.instance-variables.declator.vdmpp",
+			"name": "meta.instance-variables.declator.vdmrt",
 			"begin": "(\\S+)\\s*:\\s*([^;\\n]+)",
 			"end": ";",
 			"beginCaptures": {
@@ -131,7 +131,7 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
 							"include": "#statements"
@@ -141,7 +141,7 @@
 			}
 		},
 		"types-definition": {
-			"name": "meta.types.vdmpp",
+			"name": "meta.types.vdmrt",
 			"begin": "\\b(types)\\b",
 			"end": "(.*)(?=(operations|functions|values|instance variables|end))",
 			"beginCaptures": {
@@ -163,7 +163,7 @@
 			]
 		},
 		"types-declator": {
-			"name": "meta.types.declator.vdmpp",
+			"name": "meta.types.declator.vdmrt",
 			"begin": "(public|private)\\s+(\\S+)\\s+=\\s+([^;]+)",
 			"end": ";",
 			"beginCaptures": {
@@ -184,10 +184,10 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -200,7 +200,7 @@
 			]
 		},
 		"values-definition": {
-			"name": "meta.values.vdmpp",
+			"name": "meta.values.vdmrt",
 			"begin": "\\b(values)\\b",
 			"end": "(.*)(?=(operations|functions|types|instance variables|end))",
 			"beginCaptures": {
@@ -222,7 +222,7 @@
 			]
 		},
 		"values-declator": {
-			"name": "meta.values.declator.vdmpp",
+			"name": "meta.values.declator.vdmrt",
 			"begin": "(public|private)\\s+(static)\\s+(\\S+)\\s+:\\s+(\\S+)",
 			"end": ";",
 			"beginCaptures": {
@@ -250,10 +250,10 @@
 				"4": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -261,10 +261,10 @@
 			},
 			"endCaptures": {
 				"1": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmrt"
 				},
 				"2": {
-					"name": "entity.name.class.vdmpp"
+					"name": "entity.name.class.vdmrt"
 				}
 			},
 			"patterns": [
@@ -274,7 +274,7 @@
 			]
 		},
 		"functions-definition": {
-			"name": "meta.functions.vdmpp",
+			"name": "meta.functions.vdmrt",
 			"begin": "\\b(functions)\\b",
 			"end": ".*(?=operations|values|types|instance variables|end)",
 			"beginCaptures": {
@@ -299,7 +299,7 @@
 			]
 		},
 		"functions-declator": {
-			"name": "meta.functions.declator.vdmpp",
+			"name": "meta.functions.declator.vdmrt",
 			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -315,10 +315,10 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -332,10 +332,10 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -348,12 +348,12 @@
 			]
 		},
 		"functions-implementation": {
-			"name": "meta.functions.implementation.vdmpp",
+			"name": "meta.functions.implementation.vdmrt",
 			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
 			"end": ";",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.vdmpp"
+					"name": "entity.name.function.vdmrt"
 				}
 			},
 			"patterns": [
@@ -363,7 +363,7 @@
 			]
 		},
 		"operations-definition": {
-			"name": "meta.operations.vdmpp",
+			"name": "meta.operations.vdmrt",
 			"begin": "\\b(operations)\\b",
 			"end": "(.*)(?=(functions|values|types|instance variables|end))",
 			"beginCaptures": {
@@ -388,7 +388,7 @@
 			]
 		},
 		"operations-declator": {
-			"name": "meta.operations.declator.vdmpp",
+			"name": "meta.operations.declator.vdmrt",
 			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -404,10 +404,10 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -421,10 +421,10 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmrt.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmrt",
 							"match": "\\S+"
 						}
 					]
@@ -437,12 +437,12 @@
 			]
 		},
 		"operations-implementation": {
-			"name": "meta.operations.implementation.vdmpp",
+			"name": "meta.operations.implementation.vdmrt",
 			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
 			"end": ";",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.vdmpp"
+					"name": "entity.name.function.vdmrt"
 				}
 			},
 			"patterns": [
@@ -455,12 +455,12 @@
 			]
 		},
 		"use-function":{
-			"name": "meta.use-function.vdmpp",
+			"name": "meta.use-function.vdmrt",
 			"begin": "(\\S+)\\s*\\(",
 			"end": "\\)",
 			"beginCaptures": {
 				"1":{
-					"name": "support.function.vdmpp"
+					"name": "support.function.vdmrt"
 				}
 			}
 		}

--- a/vdmsl/package.json
+++ b/vdmsl/package.json
@@ -333,11 +333,11 @@
         "path": "./syntaxes/number.tmLanguage.json"
       },
       {
-        "scopeName": "source.vdmpp.type",
+        "scopeName": "source.vdmsl.type",
         "path": "./syntaxes/type.tmLanguage.json"
       },
       {
-        "scopeName": "source.vdmpp.statements",
+        "scopeName": "source.vdmsl.statements",
         "path": "./syntaxes/statements.tmLanguage.json"
       }
     ],

--- a/vdmsl/package.json
+++ b/vdmsl/package.json
@@ -331,6 +331,14 @@
       {
         "scopeName": "source.vdmsl.number",
         "path": "./syntaxes/number.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.type",
+        "path": "./syntaxes/type.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.vdmpp.statements",
+        "path": "./syntaxes/statements.tmLanguage.json"
       }
     ],
     "debuggers": [

--- a/vdmsl/syntaxes/statements.tmLanguage.json
+++ b/vdmsl/syntaxes/statements.tmLanguage.json
@@ -1,0 +1,109 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "statements",
+	"patterns": [
+		{
+			"include": "#statements"
+		}
+	],
+	"repository": {
+		"statements": {
+			"name": "meta.statements.vdmpp",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"include": "#control-statements"
+				},
+				{
+					"include": "#local-binding-statements"
+				},
+				{
+					"include": "#expressions"
+				},
+				{
+					"include": "#others"
+				},
+				{
+					"include": "#operator"
+				}
+			]
+		},
+		"comment": {
+			"patterns": [
+				{
+					"name": "comment.line.double-dash.vdmpp",
+					"match": "--.*"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.vdmpp",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.vdmpp",
+					"match": "\\\\."
+				}
+			]
+		},
+		"control-statements": {
+			"patterns": [
+				{
+					"name": "keyword.control.statements.conditional.vdmpp",
+					"match": "\\b(if|then|else|elseif|cases|end)\\b"
+				}
+			]
+		},
+		"local-binding-statements":{
+			"patterns": [
+				{
+					"name": "storage.type.vdmpp",
+					"match": "\\b(let)\\b"
+				}
+			]
+		},
+		"expressions": {
+			"patterns": [
+				{
+					"name": "keyword.operator.expressions.binary.vdmpp",
+					"match": "\\b(div|rem|mod|or|and|in set|not in set|subset|psubset|union|inter|munion|comp)\\b"
+				},
+				{
+					"name": "keyword.operator.expressions.unary.vdmpp",
+					"match": "\\b(abs|floor|not|card|power|dunion|dinter|hd|tl|len|elems|inds|reverse|conc|dom|rng|merge|inverse|mod|in|set|comp|and|or)\\b"
+				}
+			]
+		},
+		"others": {
+			"patterns": [
+				{
+					"name": "keyword.other.vdmsl",
+					"match": "\\b(#else|#endif|#ifdef|#ifndef|abs|all|always|and|as|atomic|be|bool|by|card|cases|char|comp|compose|conc|dcl|def|definitions|dinter|div|dlmodule|do|dom|dunion|elems|else|elseif|end|error|errs|eq|exists|exists1|exit|exports|ext|false|floor|for|forall|from|functions|hd|if|imports|in|inds|init|inmap|int|inter|inv|inverse|iota|is|lambda|len|let|map|measure|merge|mod|module|mu|munion|nat|nat1|nil|not|of|operations|or|ord|others|post|power|pre|psubset|pure|rat|rd|real|rem|renamed|return|reverse|rng|seq|seq1|set|set1|skip|specified|st|state|struct|subset|then|tixe|tl|to|token|trap|traces|true|types|undefined|union|uselib|values|while|with|wr|yet|RESULT)\\b"
+				}
+			]
+		},
+		"operator": {
+			"patterns": [
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
+				},
+				{
+					"name": "keyword.operator.assignment.vdmpp",
+					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
+				},
+				{
+					"name": "keyword.operator.new.vdmpp",
+					"match": "\\b(new)\\b"
+				}
+			]
+		}
+	},
+	"scopeName": "source.vdmpp.statements"
+}

--- a/vdmsl/syntaxes/statements.tmLanguage.json
+++ b/vdmsl/syntaxes/statements.tmLanguage.json
@@ -8,7 +8,7 @@
 	],
 	"repository": {
 		"statements": {
-			"name": "meta.statements.vdmpp",
+			"name": "meta.statements.vdmsl",
 			"patterns": [
 				{
 					"include": "#comment"
@@ -36,18 +36,18 @@
 		"comment": {
 			"patterns": [
 				{
-					"name": "comment.line.double-dash.vdmpp",
+					"name": "comment.line.double-dash.vdmsl",
 					"match": "--.*"
 				}
 			]
 		},
 		"strings": {
-			"name": "string.quoted.double.vdmpp",
+			"name": "string.quoted.double.vdmsl",
 			"begin": "\"",
 			"end": "\"",
 			"patterns": [
 				{
-					"name": "constant.character.escape.vdmpp",
+					"name": "constant.character.escape.vdmsl",
 					"match": "\\\\."
 				}
 			]
@@ -55,7 +55,7 @@
 		"control-statements": {
 			"patterns": [
 				{
-					"name": "keyword.control.statements.conditional.vdmpp",
+					"name": "keyword.control.statements.conditional.vdmsl",
 					"match": "\\b(if|then|else|elseif|cases|end)\\b"
 				}
 			]
@@ -63,7 +63,7 @@
 		"local-binding-statements":{
 			"patterns": [
 				{
-					"name": "storage.type.vdmpp",
+					"name": "storage.type.vdmsl",
 					"match": "\\b(let)\\b"
 				}
 			]
@@ -71,11 +71,11 @@
 		"expressions": {
 			"patterns": [
 				{
-					"name": "keyword.operator.expressions.binary.vdmpp",
+					"name": "keyword.operator.expressions.binary.vdmsl",
 					"match": "\\b(div|rem|mod|or|and|in set|not in set|subset|psubset|union|inter|munion|comp)\\b"
 				},
 				{
-					"name": "keyword.operator.expressions.unary.vdmpp",
+					"name": "keyword.operator.expressions.unary.vdmsl",
 					"match": "\\b(abs|floor|not|card|power|dunion|dinter|hd|tl|len|elems|inds|reverse|conc|dom|rng|merge|inverse|mod|in|set|comp|and|or)\\b"
 				}
 			]
@@ -91,19 +91,19 @@
 		"operator": {
 			"patterns": [
 				{
-					"name": "keyword.operator.assignment.vdmpp",
+					"name": "keyword.operator.assignment.vdmsl",
 					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
 				},
 				{
-					"name": "keyword.operator.assignment.vdmpp",
+					"name": "keyword.operator.assignment.vdmsl",
 					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
 				},
 				{
-					"name": "keyword.operator.new.vdmpp",
+					"name": "keyword.operator.new.vdmsl",
 					"match": "\\b(new)\\b"
 				}
 			]
 		}
 	},
-	"scopeName": "source.vdmpp.statements"
+	"scopeName": "source.vdmsl.statements"
 }

--- a/vdmsl/syntaxes/type.tmLanguage.json
+++ b/vdmsl/syntaxes/type.tmLanguage.json
@@ -19,7 +19,7 @@
                     "include": "#enum"
                 },
 				{
-					"name": "support.type.basic.vdmpp",
+					"name": "support.type.basic.vdmsl",
 					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
 				}
 			]
@@ -28,10 +28,10 @@
 			"match": "(seq of) (\\S+)",
 			"captures": {
 				"1": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmsl"
 				},
 				"2": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmsl"
 				}
 			}
 		},
@@ -39,16 +39,16 @@
 			"match": "(map) (\\S+) (to) (\\S+)",
 			"captures": {
 				"1": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmsl"
 				},
 				"2": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmsl"
 				},
 				"3": {
-					"name": "support.type.basic.vdmpp"
+					"name": "support.type.basic.vdmsl"
 				},
 				"4": {
-					"name": "storage.type.vdmpp"
+					"name": "storage.type.vdmsl"
 				}
 			}
         },
@@ -56,10 +56,10 @@
             "match": "<([^>]+)>",
             "captures": {
                 "1": {
-                    "name": "support.type.basic.vdmpp"
+                    "name": "support.type.basic.vdmsl"
                 }
             }
         }
 	},
-	"scopeName": "source.vdmpp.type"
+	"scopeName": "source.vdmsl.type"
 }

--- a/vdmsl/syntaxes/type.tmLanguage.json
+++ b/vdmsl/syntaxes/type.tmLanguage.json
@@ -1,0 +1,65 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "type",
+	"patterns": [
+		{
+			"include": "#type"
+		}
+	],
+	"repository": {
+		"type": {
+			"patterns": [
+				{
+					"include": "#seq-of"
+				},
+				{
+					"include": "#map-to"
+                },
+                {
+                    "include": "#enum"
+                },
+				{
+					"name": "support.type.basic.vdmpp",
+					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
+				}
+			]
+		},
+		"seq-of": {
+			"match": "(seq of) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+		},
+		"map-to": {
+			"match": "(map) (\\S+) (to) (\\S+)",
+			"captures": {
+				"1": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"2": {
+					"name": "storage.type.vdmpp"
+				},
+				"3": {
+					"name": "support.type.basic.vdmpp"
+				},
+				"4": {
+					"name": "storage.type.vdmpp"
+				}
+			}
+        },
+        "enum":{
+            "match": "<([^>]+)>",
+            "captures": {
+                "1": {
+                    "name": "support.type.basic.vdmpp"
+                }
+            }
+        }
+	},
+	"scopeName": "source.vdmpp.type"
+}

--- a/vdmsl/syntaxes/vdmsl.tmLanguage.json
+++ b/vdmsl/syntaxes/vdmsl.tmLanguage.json
@@ -31,20 +31,20 @@
 					"include": "#definitions"
 				},
 				{
-					"include": "source.vdmpp.type"
+					"include": "source.vdmsl.type"
 				},
 				{
 					"include": "source.vdmsl.number"
 				},
 				{
-					"include": "source.vdmpp.statements"
+					"include": "source.vdmsl.statements"
 				}
 			]
 		},
 		"definitions": {
 			"patterns": [
 				{
-					"name": "entity.name.function.vdmpp",
+					"name": "entity.name.function.vdmsl",
 					"match": "\\b(operations|functions|types|values|instance variables)\\b"
 				}
 			]
@@ -52,7 +52,7 @@
 		"modifier": {
 			"patterns": [
 				{
-					"name": "storage.modifier.vdmpp",
+					"name": "storage.modifier.vdmsl",
 					"match": "\\b(public|private|static|pre|post|pure)\\b"
 				}
 			]
@@ -60,13 +60,13 @@
 		"variable-name": {
 			"patterns": [
 				{
-					"name": "variable.other.readwrite.vdmpp",
+					"name": "variable.other.readwrite.vdmsl",
 					"match": "([^:()\\s=>])"
 				}
 			]
 		},
 		"instance-variables-definition": {
-			"name": "meta.instance-variables.vdmpp",
+			"name": "meta.instance-variables.vdmsl",
 			"begin": "\\b(instance variables)\\b",
 			"end": "(.*)(?=(operations|functions|types|values|end))",
 			"beginCaptures": {
@@ -88,7 +88,7 @@
 			]
 		},
 		"instance-variables-declator": {
-			"name": "meta.instance-variables.declator.vdmpp",
+			"name": "meta.instance-variables.declator.vdmsl",
 			"begin": "(\\S+)\\s*:\\s*([^;\\n]+)",
 			"end": ";",
 			"beginCaptures": {
@@ -102,7 +102,7 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
 							"include": "#statements"
@@ -112,7 +112,7 @@
 			}
 		},
 		"types-definition": {
-			"name": "meta.types.vdmpp",
+			"name": "meta.types.vdmsl",
 			"begin": "\\b(types)\\b",
 			"end": "(.*)(?=(operations|functions|values|instance variables|end))",
 			"beginCaptures": {
@@ -134,7 +134,7 @@
 			]
 		},
 		"types-declator": {
-			"name": "meta.types.declator.vdmpp",
+			"name": "meta.types.declator.vdmsl",
 			"begin": "(public|private)\\s+(\\S+)\\s+=\\s+([^;]+)",
 			"end": ";",
 			"beginCaptures": {
@@ -155,10 +155,10 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmsl",
 							"match": "\\S+"
 						}
 					]
@@ -171,7 +171,7 @@
 			]
 		},
 		"values-definition": {
-			"name": "meta.values.vdmpp",
+			"name": "meta.values.vdmsl",
 			"begin": "\\b(values)\\b",
 			"end": "(.*)(?=(operations|functions|types|instance variables|end))",
 			"beginCaptures": {
@@ -193,7 +193,7 @@
 			]
 		},
 		"values-declator": {
-			"name": "meta.values.declator.vdmpp",
+			"name": "meta.values.declator.vdmsl",
 			"begin": "(public|private)\\s+(static)\\s+(\\S+)\\s+:\\s+(\\S+)",
 			"end": ";",
 			"beginCaptures": {
@@ -221,10 +221,10 @@
 				"4": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmsl",
 							"match": "\\S+"
 						}
 					]
@@ -245,7 +245,7 @@
 			]
 		},
 		"functions-definition": {
-			"name": "meta.functions.vdmpp",
+			"name": "meta.functions.vdmsl",
 			"begin": "\\b(functions)\\b",
 			"end": ".*(?=operations|values|types|instance variables|end)",
 			"beginCaptures": {
@@ -270,7 +270,7 @@
 			]
 		},
 		"functions-declator": {
-			"name": "meta.functions.declator.vdmpp",
+			"name": "meta.functions.declator.vdmsl",
 			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -286,10 +286,10 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
-							"name": "support.type.primitive.vdmpp",
+							"name": "support.type.primitive.vdmsl",
 							"match": "\\S+"
 						}
 					]
@@ -303,7 +303,7 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
 							"name": "support.type.primitive.vdmsl",
@@ -319,12 +319,12 @@
 			]
 		},
 		"functions-implementation": {
-			"name": "meta.functions.implementation.vdmpp",
+			"name": "meta.functions.implementation.vdmsl",
 			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
 			"end": ";",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.vdmpp"
+					"name": "entity.name.function.vdmsl"
 				}
 			},
 			"patterns": [
@@ -334,7 +334,7 @@
 			]
 		},
 		"operations-definition": {
-			"name": "meta.operations.vdmpp",
+			"name": "meta.operations.vdmsl",
 			"begin": "\\b(operations)\\b",
 			"end": "(.*)(?=(functions|values|types|instance variables|end))",
 			"beginCaptures": {
@@ -359,7 +359,7 @@
 			]
 		},
 		"operations-declator": {
-			"name": "meta.operations.declator.vdmpp",
+			"name": "meta.operations.declator.vdmsl",
 			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -375,7 +375,7 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
 							"name": "support.type.primitive.vdmsl",
@@ -392,7 +392,7 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "source.vdmpp.type"
+							"include": "source.vdmsl.type"
 						},
 						{
 							"name": "support.type.primitive.vdmsl",
@@ -408,12 +408,12 @@
 			]
 		},
 		"operations-implementation": {
-			"name": "meta.operations.implementation.vdmpp",
+			"name": "meta.operations.implementation.vdmsl",
 			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
 			"end": ";",
 			"beginCaptures": {
 				"1": {
-					"name": "entity.name.function.vdmpp"
+					"name": "entity.name.function.vdmsl"
 				}
 			},
 			"patterns": [
@@ -426,12 +426,12 @@
 			]
 		},
 		"use-function":{
-			"name": "meta.use-function.vdmpp",
+			"name": "meta.use-function.vdmsl",
 			"begin": "(\\S+)\\s*\\(",
 			"end": "\\)",
 			"beginCaptures": {
 				"1":{
-					"name": "support.function.vdmpp"
+					"name": "support.function.vdmsl"
 				}
 			}
 		}

--- a/vdmsl/syntaxes/vdmsl.tmLanguage.json
+++ b/vdmsl/syntaxes/vdmsl.tmLanguage.json
@@ -3,18 +3,27 @@
 	"name": "VDM",
 	"patterns": [
 		{
-			"include": "#class-declator"
+			"include": "#functions-definition"
 		},
 		{
-			"include": "#statement"
+			"include": "#operations-definition"
+		},
+		{
+			"include": "#values-definition"
+		},
+		{
+			"include": "#types-definition"
+		},
+		{
+			"include": "#instance-variables-definition"
+		},
+		{
+			"include": "#statements"
 		}
 	],
 	"repository": {
-		"statement": {
+		"statements": {
 			"patterns": [
-				{
-					"include": "#comment"
-				},
 				{
 					"include": "#modifier"
 				},
@@ -22,153 +31,169 @@
 					"include": "#definitions"
 				},
 				{
-					"include": "#strings"
-				},
-				{
-					"include": "#types"
-				},
-				{
-					"include": "#keywords"
+					"include": "source.vdmpp.type"
 				},
 				{
 					"include": "source.vdmsl.number"
 				},
 				{
-					"include": "#method-name"
-				},
-				{
-					"include": "#operator"
-				}
-			]
-		},
-		"comment": {
-			"patterns": [
-				{
-					"name": "comment.line.double-dash.vdmsl",
-					"match": "--.*"
+					"include": "source.vdmpp.statements"
 				}
 			]
 		},
 		"definitions": {
 			"patterns": [
 				{
-					"name": "entity.name.section.vdmsl",
+					"name": "entity.name.function.vdmpp",
 					"match": "\\b(operations|functions|types|values|instance variables)\\b"
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"name": "keyword.control.vdmsl",
-					"match": "\\b(if|else|then|return|forall)\\b"
-				}
-			]
-		},
-		"method-name": {
-			"name": "meta.use-method.vdmsl",
-			"begin": "(\\S+)\\(",
-			"end": "\\)",
-			"beginCaptures": {
-				"1": {
-					"name": "entity.name.function.vdmsl"
-				}
-			},
-			"patterns": [
-				{
-					"include": "#variable-name"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.vdmsl",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.vdmsl",
-					"match": "\\\\."
 				}
 			]
 		},
 		"modifier": {
 			"patterns": [
 				{
-					"name": "storage.modifier.vdmsl",
+					"name": "storage.modifier.vdmpp",
 					"match": "\\b(public|private|static|pre|post|pure)\\b"
-				},
-				{
-					"name": "storage.type.vdmsl",
-					"match": "\\b(let)\\b"
-				}
-			]
-		},
-		"types": {
-			"patterns": [
-				{
-					"name": "support.type.basic.vdmsl",
-					"match": "\\b(bool|nat|nat1|int|rat|real|char|token)\\b"
-				}
-			]
-		},
-		"operator": {
-			"patterns": [
-				{
-					"name": "keyword.operator.assignment.vdmsl",
-					"match": "(\\||\\&|=|\\+|-|\\*|\\/|>|<)"
-				},
-				{
-					"name": "keyword.operator.assignment.vdmsl",
-					"match": "\\b(mod|in set|dom|comp|iterate|and|or|abs|floor|card|power|dunion|dinter)\\b"
-				},
-				{
-					"name": "keyword.operator.new.vdmsl",
-					"match": "\\b(new)\\b"
 				}
 			]
 		},
 		"variable-name": {
 			"patterns": [
 				{
-					"name": "variable.other.readwrite.vdmsl",
+					"name": "variable.other.readwrite.vdmpp",
 					"match": "([^:()\\s=>])"
 				}
 			]
 		},
-		"class-declator": {
-			"name": "meta.class.vdmsl",
-			"begin": "(class)\\s+(\\S+)",
-			"end": "(end)\\s+(\\S+)",
+		"instance-variables-definition": {
+			"name": "meta.instance-variables.vdmpp",
+			"begin": "\\b(instance variables)\\b",
+			"end": "(.*)(?=(operations|functions|types|values|end))",
 			"beginCaptures": {
 				"1": {
-					"name": "storage.type.vdmsl"
-				},
-				"2": {
-					"name": "entity.name.class.vdmsl"
-				}
-			},
-			"endCaptures": {
-				"1": {
-					"name": "storage.type.vdmsl"
-				},
-				"2": {
-					"name": "entity.name.class.vdmsl"
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
 				}
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
+					"include": "#instance-variables-declator"
 				},
 				{
-					"include": "#value-declator"
-				},
-				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
 		},
-		"value-declator": {
-			"name": "meta.value.vdmsl",
+		"instance-variables-declator": {
+			"name": "meta.instance-variables.declator.vdmpp",
+			"begin": "(\\S+)\\s*:\\s*([^;\\n]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"include": "#statements"
+						}
+					]
+				}
+			}
+		},
+		"types-definition": {
+			"name": "meta.types.vdmpp",
+			"begin": "\\b(types)\\b",
+			"end": "(.*)(?=(operations|functions|values|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#types-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"types-declator": {
+			"name": "meta.types.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s+=\\s+([^;]+)",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "#variable-name"
+						}
+					]
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmpp",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-definition": {
+			"name": "meta.values.vdmpp",
+			"begin": "\\b(values)\\b",
+			"end": "(.*)(?=(operations|functions|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#values-declator"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"values-declator": {
+			"name": "meta.values.declator.vdmpp",
 			"begin": "(public|private)\\s+(static)\\s+(\\S+)\\s+:\\s+(\\S+)",
 			"end": ";",
 			"beginCaptures": {
@@ -196,10 +221,10 @@
 				"4": {
 					"patterns": [
 						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
-							"name": "support.type.primitive.vdmsl",
+							"name": "support.type.primitive.vdmpp",
 							"match": "\\S+"
 						}
 					]
@@ -215,16 +240,38 @@
 			},
 			"patterns": [
 				{
-					"include": "#function-declator"
-				},
-				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
 		},
-		"function-declator": {
-			"name": "meta.function.vdmsl",
-			"begin": "(public|private)\\s+(\\S+)\\s+:\\s+(\\S+)\\s+(==>|->)\\s+(seq of char|\\S+)",
+		"functions-definition": {
+			"name": "meta.functions.vdmpp",
+			"begin": "\\b(functions)\\b",
+			"end": ".*(?=operations|values|types|instance variables|end)",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#functions-declator"
+				},
+				{
+					"include": "#functions-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"functions-declator": {
+			"name": "meta.functions.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
 			"beginCaptures": {
 				"1": {
 					"patterns": [
@@ -239,21 +286,24 @@
 				"3": {
 					"patterns": [
 						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
-							"name": "support.type.primitive.vdmsl",
+							"name": "support.type.primitive.vdmpp",
 							"match": "\\S+"
 						}
 					]
-				},
-				"4": {
+				}
+			},
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
 					"name": "storage.type.function.arrow.js"
 				},
-				"5": {
+				"2": {
 					"patterns": [
 						{
-							"include": "#types"
+							"include": "source.vdmpp.type"
 						},
 						{
 							"name": "support.type.primitive.vdmsl",
@@ -262,12 +312,128 @@
 					]
 				}
 			},
-			"end": ";",
 			"patterns": [
 				{
-					"include": "#statement"
+					"include": "#statements"
 				}
 			]
+		},
+		"functions-implementation": {
+			"name": "meta.functions.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-definition": {
+			"name": "meta.operations.vdmpp",
+			"begin": "\\b(operations)\\b",
+			"end": "(.*)(?=(functions|values|types|instance variables|end))",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#definitions"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#operations-declator"
+				},
+				{
+					"include": "#operations-implementation"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-declator": {
+			"name": "meta.operations.declator.vdmpp",
+			"begin": "(public|private)\\s+(\\S+)\\s*:\\s*(\\S+)\\s+",
+			"beginCaptures": {
+				"1": {
+					"patterns": [
+						{
+							"include": "#modifier"
+						}
+					]
+				},
+				"2": {
+					"name": "entity.name.function"
+				},
+				"3": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmsl",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"end": "(==>|->)\\s+(seq of char|\\S+)",
+			"endCaptures": {
+				"1": {
+					"name": "storage.type.function.arrow.js"
+				},
+				"2": {
+					"patterns": [
+						{
+							"include": "source.vdmpp.type"
+						},
+						{
+							"name": "support.type.primitive.vdmsl",
+							"match": "\\S+"
+						}
+					]
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"operations-implementation": {
+			"name": "meta.operations.implementation.vdmpp",
+			"begin": "(\\S+)\\s*\\(\\s*\\S*\\s*\\)\\s*==",
+			"end": ";",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.vdmpp"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#use-function"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"use-function":{
+			"name": "meta.use-function.vdmpp",
+			"begin": "(\\S+)\\s*\\(",
+			"end": "\\)",
+			"beginCaptures": {
+				"1":{
+					"name": "support.function.vdmpp"
+				}
+			}
 		}
 	},
 	"scopeName": "source.vdmsl"


### PR DESCRIPTION
# Description
- Highlights reserved words for VDM-SL, VDM-PP, and VDM-RT, respectively. 
- Some VDM++ syntax has also been modified to highlight.
- Split tmLanguage to make it easier to maintain.

# Note
- Since VDM-SL and VDM-RT used the existing tmLanguage for VDM++, their reserved word settings are based on the tmLanguage for VDM++. From now on, we need to create optimized tmLanguages for VDM-SL and VDM-RT, respectively.

# Screenshot
## VDM-SL
<img width="290" alt="スクリーンショット 2020-11-26 18 46 25" src="https://user-images.githubusercontent.com/20027695/100335080-e6d48300-3017-11eb-960f-34b9e0ef17ae.png"> <img width="298" alt="スクリーンショット 2020-11-26 18 45 14" src="https://user-images.githubusercontent.com/20027695/100335075-e5a35600-3017-11eb-8244-a5bb1e7042c6.png">

←before | after→

## VDM-PP
<img width="333" alt="スクリーンショット 2020-11-26 18 26 28" src="https://user-images.githubusercontent.com/20027695/100332889-4b421300-3015-11eb-8575-d57f7d0298db.png"> <img width="325" alt="スクリーンショット 2020-11-26 18 33 02" src="https://user-images.githubusercontent.com/20027695/100333478-fa7eea00-3015-11eb-9175-baeda33333a5.png">

←before | after→

## VDM-RT
<img width="366" alt="スクリーンショット 2020-11-26 18 28 46" src="https://user-images.githubusercontent.com/20027695/100332898-4ed59a00-3015-11eb-943b-2e3228aa3643.png"> <img width="354" alt="スクリーンショット 2020-11-26 18 37 42" src="https://user-images.githubusercontent.com/20027695/100333916-7c6f1300-3016-11eb-9859-c0cbeff78adb.png">

←before | after→
